### PR TITLE
Enhance 'prompt_hook' for better key handling

### DIFF
--- a/workflow_component/custom_server.py
+++ b/workflow_component/custom_server.py
@@ -53,7 +53,10 @@ async def original_post_prompt(request):
 async def prompt_hook(request):
     json_data = await request.json()
 
-    nodes = json_data['extra_data']['extra_pnginfo']['workflow']['nodes']
+    extra_data = json_data.get('extra_data', {})
+    extra_pnginfo = extra_data.get('extra_pnginfo', {})
+    workflow = extra_pnginfo.get('workflow', {})
+    nodes = workflow.get('nodes', [])
     if any(node['type'] in ["ComponentInput", "ComponentOutput", "ComponentOptional"] for node in nodes):
         msg = "<B>The Workflow Component being composed is not executable.</B><BR><BR>If ComponentInput, ComponentInputOptional, or ComponentOutput nodes are used, it is considered that the Component being composed is in progress."
         return web.json_response({"error": {"message": msg}, "node_errors": {}}, status=400)


### PR DESCRIPTION
I hope this message finds you well.

Recently, while trying out the API request example code found at [this location](https://github.com/comfyanonymous/ComfyUI/blob/master/script_examples/basic_api_example.py), I encountered a KeyError: 'extra_data'. Upon investigation, I noticed that the current implementation of the prompt_hook function directly accesses the dictionary keys 'extra_data', 'extra_pnginfo', 'workflow', and 'nodes', which could lead to a KeyError if these keys do not exist.

To address this, I am submitting this Pull Request, offering an improvement to this section of the code. I suggest utilizing the .get() method for dictionary access to retrieve these keys safely. The .get() method will return a default value if the keys do not exist, thereby avoiding the KeyError.

Here is the modified section of the code:

```
extra_data = json_data.get('extra_data', {})
extra_pnginfo = extra_data.get('extra_pnginfo', {})
workflow = extra_pnginfo.get('workflow', {})
nodes = workflow.get('nodes', [])
```

I believe this small adjustment can significantly enhance the stability and reliability of the ComfyUI project when handling unpredictable requests.

Once again, thank you for your tremendous contributions to this project. I look forward to your feedback on this proposed enhancement.